### PR TITLE
fix premature GC of supervisor process

### DIFF
--- a/pqx_test.go
+++ b/pqx_test.go
@@ -105,6 +105,22 @@ func TestOrphan(t *testing.T) {
 
 }
 
+func TestParallel(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		t.Run("r", func(t *testing.T) {
+			t.Parallel()
+			db := pqxtest.CreateDB(t, "")
+			_, err := db.Exec(`SELECT 1`)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+	t.Run("wait", func(t *testing.T) {
+		t.Logf("waiting")
+	})
+}
+
 func scanString(t *testing.T, r io.Reader, format string) string {
 	t.Helper()
 	var s string

--- a/pqxtest/supervise/supervise.go
+++ b/pqxtest/supervise/supervise.go
@@ -50,4 +50,14 @@ func This(pid int) {
 	if err != nil {
 		panic(err)
 	}
+
+	go func() {
+		// Exiting this function without this reference to sup means
+		// cmd is sent to the heap, where it will be eligible for GC,
+		// possibly too early, causing the stdin pipe to be closed
+		// early which will cause the supervisor to exit early, and
+		// kill postgres too early, leading test failures, and sad
+		// developers.
+		_ = sup.Wait()
+	}()
 }


### PR DESCRIPTION
Previously, the *exec.Cmd that started (but did not wait for) the
supervisor process, was not referenced by anything, and so it was garbage
collected along with its stdin pipe, which cause the child process to
observe stdin close, and assume its parent died, and so it sent SIGQUIT
to Postgres too early, and tests would fail thereafter.
