### PR TITLE
pqx: avoid issue with long database names

### DIFF
--- a/pqx_test.go
+++ b/pqx_test.go
@@ -71,6 +71,19 @@ func TestSubTestNames(t *testing.T) {
 	}
 }
 
+func TestLongNames(t *testing.T) {
+	prefix := strings.Repeat("a", 100)
+
+	cases := []string{
+		prefix + "a",
+		prefix + "b",
+	}
+
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) { pqxtest.CreateDB(t, "") })
+	}
+}
+
 func TestOrphan(t *testing.T) {
 	exe, err := os.Executable()
 	if err != nil {

--- a/pqxtest/pqxtest.go
+++ b/pqxtest/pqxtest.go
@@ -236,6 +236,9 @@ func CreateDB(t testing.TB, schema string) *sql.DB {
 	})
 
 	name := cleanName(t.Name())
+	if len(name) > 54 {
+		name = name[0:53]
+	}
 	name = fmt.Sprintf("%s_%s", name, randomString())
 	db, dsn, cleanup, err := sharedPG.CreateDB(context.Background(), t.Logf, name, schema)
 	if err != nil {


### PR DESCRIPTION
Postgres truncates table names over 63 bytes, which means pqx may attempt to create duplicates.